### PR TITLE
POST websocket JSON

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,12 +1,12 @@
 require (
 	github.com/Pallinder/go-randomdata v1.1.0
 	github.com/golang/protobuf v1.2.0
-	github.com/gorilla/websocket v1.4.0 // indirect
+	github.com/gorilla/websocket v1.4.0
 	github.com/grpc-ecosystem/grpc-gateway v1.5.1
 	github.com/improbable-eng/grpc-web v0.0.0-20181031170435-f683dbb3b587
 	github.com/rs/cors v1.6.0 // indirect
 	github.com/segmentio/ksuid v1.0.2
-	github.com/sirupsen/logrus v1.2.0 // indirect
+	github.com/sirupsen/logrus v1.2.0
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6
 	golang.org/x/net v0.0.0-20181029044818-c44066c5c816
 	google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8

--- a/backend/main.go
+++ b/backend/main.go
@@ -94,7 +94,7 @@ func main() {
 		grpclog.Infof("Starting gRPC-gateway server. https port: %v", *gatewayPort)
 		grpcGateway := http.Server{
 			Addr: fmt.Sprintf(":%v", *gatewayPort),
-			Handler: wsproxy.WebsocketProxy(mux),
+			Handler: wsproxy.WebsocketProxy(mux, wsproxy.WithMethodParamOverride("method")),
 			ErrorLog: logger,
 		}
 		errChannel <- grpcGateway.ListenAndServe()

--- a/backend/main.go
+++ b/backend/main.go
@@ -82,7 +82,7 @@ func main() {
 
 	// running proxy for grpc-web
 	go func () {
-		grpclog.Infof("Starting grpc-web proxy server. https port: %v", *grpcwPort)
+		grpclog.Infof("Starting grpc-web proxy server. http port: %v", *grpcwPort)
 		errChannel <- httpServer.ListenAndServe()
 	}()
 
@@ -90,7 +90,7 @@ func main() {
 	go func () {
 		errChannel <- dog.RegisterDogTrackHandlerFromEndpoint(
 			context.Background(), mux, fmt.Sprintf("localhost:%v", *grpcPort), opts)
-		grpclog.Infof("Starting gRPC-gateway server. https port: %v", *gatewayPort)
+		grpclog.Infof("Starting gRPC-gateway server. http port: %v", *gatewayPort)
 		grpcGateway := http.Server{
 			Addr: fmt.Sprintf(":%v", *gatewayPort),
 			Handler: wsproxy.WebsocketProxy(mux, wsproxy.WithMethodParamOverride("method")),

--- a/backend/main.go
+++ b/backend/main.go
@@ -45,7 +45,6 @@ var numberDaycares = flag.Int(
 	"number of daycares to generate")
 
 func main() {
-
 	// setup for gRPC server
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%v", *grpcPort))
 	if err != nil {

--- a/proto/dog.proto
+++ b/proto/dog.proto
@@ -52,7 +52,8 @@ enum DogStatus {
 service DogTrack {
     rpc TrackDogs (TrackRequest) returns (stream Dog) {
          option (google.api.http) = {
-             get: "/v1/dogs/track"
+             post: "/v1/dogs/track"
+             body: "*"
          };
     }
     rpc AddDog (Dog) returns (Response) {

--- a/web-ws/src/index.js
+++ b/web-ws/src/index.js
@@ -2,10 +2,16 @@ window.onSubmit = event => {
   event.preventDefault();
   const locationID = document.querySelector("#location-id").value;
   const floorID = "1";
+  const object = {
+      location_id: locationID,
+      floor_id: floorID,
+  }
+  // making a websocket request, but adding in a param for method overriding for our proxy server
   const ws = new WebSocket(
-    `ws://${window.location.hostname}:8081/v1/dogs/track?location_id=${locationID}&floor_id=${floorID}`
+    `ws://${window.location.hostname}:8081/v1/dogs/track?method=POST`
   );
   ws.addEventListener("open", event => {
+    ws.send(JSON.stringify(object));
     console.log("open", event);
   });
   ws.addEventListener("message", event => {


### PR DESCRIPTION
This PR makes the websocket example work with JSON data in a POST request rather than a GET:

The problem was found when I couldn't properly encode more complicated objects into query params, and found them to be very difficult to use when trying to send data to initialize the connection. Instead of continuing to use GET, I've change to use a parameter to allow a method override, and override to POST to send a proper json payload across the websocket connection.